### PR TITLE
perf(refactor,feature-dev): harness design overhaul + Codex review fixes

### DIFF
--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -172,11 +172,21 @@ def _normalize_typescript_coverage(data: dict[str, Any]) -> CoverageData:
         covered_lines += file_covered
 
         if file_covered < file_total:
-            uncovered = [int(k) for k, v in stmt_hits.items() if v == 0]
+            # Map statement IDs to actual source line numbers via statementMap.
+            # In c8/Istanbul JSON, keys in `s` are statement IDs (e.g., "0", "1"),
+            # NOT line numbers. The statementMap entry for each ID contains
+            # {"start": {"line": N}, "end": {"line": M}}.
+            uncovered_lines: list[int] = []
+            for stmt_id, hit_count in stmt_hits.items():
+                if hit_count == 0:
+                    stmt_loc = stmt_map.get(stmt_id, {})
+                    start_line = stmt_loc.get("start", {}).get("line")
+                    if start_line is not None:
+                        uncovered_lines.append(start_line)
             uncovered_files.append(
                 {
                     "file": filename,
-                    "uncovered_lines": uncovered,
+                    "uncovered_lines": sorted(set(uncovered_lines)),
                 }
             )
 

--- a/scripts/detect_project.py
+++ b/scripts/detect_project.py
@@ -124,3 +124,18 @@ def detect_project(path: str) -> ProjectInfo:
         "test_dirs": test_dirs,
         "existing_tests": existing_tests,
     }
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: python -m scripts.detect_project <target_path>", file=sys.stderr)
+        sys.exit(1)
+    try:
+        result = detect_project(sys.argv[1])
+        print(json.dumps(result, indent=2))
+    except (ProjectDetectionError, UnsupportedLanguageError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -57,6 +57,31 @@ _TYPESCRIPT_PATTERNS: dict[str, str] = {
 }
 
 
+def _parse_typescript_output(output: str) -> TestCounts:
+    """Parse vitest summary, preferring the 'Tests' line over 'Test Files'.
+
+    Vitest emits two summary lines:
+      Test Files  1 passed (1)
+      Tests       42 passed (42)
+
+    A naive first-match regex hits the 'Test Files' line and reports
+    passed=1 instead of passed=42. This parser looks for the 'Tests'
+    summary line specifically and falls back to the generic regex only
+    if no 'Tests' line is found.
+    """
+    tests_section = re.search(r"^\s*Tests\s+(.+)$", output, re.MULTILINE)
+    if tests_section:
+        line = tests_section.group(1)
+        passed_m = re.search(r"(\d+)\s+passed", line)
+        failed_m = re.search(r"(\d+)\s+failed", line)
+        return {
+            "passed": int(passed_m.group(1)) if passed_m else 0,
+            "failed": int(failed_m.group(1)) if failed_m else 0,
+            "errors": 0,
+        }
+    return _parse_regex_counts(output, _TYPESCRIPT_PATTERNS)
+
+
 def _parse_rust_output(output: str) -> TestCounts:
     """Parse cargo test summary line: 'test result: ok. X passed; Y failed; Z ignored'."""
     match = re.search(
@@ -75,11 +100,6 @@ def _parse_rust_output(output: str) -> TestCounts:
 def _parse_python_output(output: str) -> TestCounts:
     """Parse pytest summary line: 'X passed, Y failed, Z error'."""
     return _parse_regex_counts(output, _PYTHON_PATTERNS)
-
-
-def _parse_typescript_output(output: str) -> TestCounts:
-    """Parse vitest summary: 'Tests  X passed | Y failed'."""
-    return _parse_regex_counts(output, _TYPESCRIPT_PATTERNS)
 
 
 def _parse_go_output(output: str) -> TestCounts:

--- a/skills/feature-dev/SKILL.md
+++ b/skills/feature-dev/SKILL.md
@@ -38,8 +38,10 @@ Parse `$ARGUMENTS` for the following **before** any other processing:
      - **Phase 3 (Clarifying Questions)**: Skip user interaction. Make design decisions based on codebase patterns discovered in Phase 2. Document decisions made.
      - **Phase 4 (Architecture Selection)**: Instead of presenting options to the user, evaluate all architect proposals and select the best one automatically using this priority: (1) highest alignment with existing codebase conventions, (2) pragmatic balance of quality and simplicity, (3) smallest blast radius. Document the choice and rationale.
      - **Phase 5 (Implementation Approval)**: Skip — proceed directly.
-     - **Phase 6 (Review Disposition)**: Auto-fix all findings with confidence >= 80. Override quality gate only if rigor >= 0.5 and coverage >= 60% (relaxed thresholds for autonomous). Document any overrides.
+     - **Phase 6 (Review Disposition)**: Auto-fix all findings with confidence >= 80. Override quality gate only if rigor >= `config.featureDev.testArchitect.autonomousMinimumRigorScore` (default: 0.5) and coverage >= `config.featureDev.testArchitect.autonomousMinimumCoverage` (default: 60%). These thresholds are configurable — raise them for stricter autonomous quality gates. Document any overrides.
   If `--autonomous` is not present, set `autonomous_mode = false` and all interactive gates operate normally.
+
+- `--context-reset` — Reset orchestrator context between major phases. Writes full state to blackboard checkpoint, then spawns a fresh session to continue. Use for extremely long autonomous runs (20+ iterations). Default: summarize-and-discard without context reset.
 
 - `--iterations=N` — Override the max iteration count for autonomous mode. `N` must be a positive integer (1-20). If present, extract and remove from `$ARGUMENTS` and store as `cli_iterations`. Only meaningful when combined with `--autonomous`.
 
@@ -71,7 +73,9 @@ After extracting flags, the remaining `$ARGUMENTS` is the feature description. I
     "testArchitect": {
       "enabled": true,
       "minimumRigorScore": 0.7,
-      "minimumCoverage": 80
+      "minimumCoverage": 80,
+      "autonomousMinimumRigorScore": 0.5,    // Minimum rigor score for autonomous quality gate override
+      "autonomousMinimumCoverage": 60        // Minimum coverage % for autonomous quality gate override
     }
   }
 }
@@ -89,7 +93,9 @@ After extracting flags, the remaining `$ARGUMENTS` is the feature description. I
   "testArchitect": {
     "enabled": true,
     "minimumRigorScore": 0.7,
-    "minimumCoverage": 80
+    "minimumCoverage": 80,
+    "autonomousMinimumRigorScore": 0.5,
+    "autonomousMinimumCoverage": 60
   }
 }
 ```
@@ -135,7 +141,33 @@ You MUST use the full swarm pattern: TeamCreate → TaskCreate → Agent with te
    - "Phase 6: Quality Review"
    - "Phase 7: Summary + Cleanup"
 
-   After all 8 tasks are created, **proceed immediately to Phase 1** (Phase 0.2 is a template reference, not an action step).
+   After all 8 tasks are created, **proceed immediately to Step 0.1.5** (checkpoint check).
+
+### Step 0.1.5: Check for Existing Checkpoint
+
+Check blackboard for existing checkpoint from a prior interrupted run:
+
+  blackboard_read(task_id="{blackboard_id}", key="checkpoint")
+
+If checkpoint exists and is valid (non-null, has checkpoint_phase field):
+  - Display: "Found checkpoint from prior run: {checkpoint_phase}, Feature: {feature_summary}."
+  - In interactive mode: Ask user "Resume from checkpoint or restart fresh?"
+  - In autonomous mode: Resume automatically.
+  - If resume: restore state variables (phase, iteration, feature_spec, chosen_architecture) from checkpoint, skip completed phases
+  - If restart: clear checkpoint via blackboard_write with empty value
+
+After each major phase completes, write checkpoint to blackboard:
+  blackboard_write(task_id="{blackboard_id}", key="checkpoint", value=JSON.stringify({
+    checkpoint_phase: "Phase N",
+    iteration: current_iteration (if autonomous),
+    best_score: best.score (if autonomous),
+    feature_spec: feature_spec_summary,
+    chosen_architecture: architecture_name,
+    files_modified: [...],
+    autonomous_mode: boolean
+  }))
+
+**Checkpoint write points**: Write checkpoint after Phase 2 (exploration), Phase 4 (architecture), Phase 4.5 (test plan), and in the autonomous loop after LOG (Step 5.2.D).
 
 ## Phase 0.2: Task Discovery Protocol Template
 
@@ -266,6 +298,16 @@ SendMessage to "code-explorer-{i}": "Task #{id} assigned: codebase exploration. 
    ```
 6. Present comprehensive summary of findings and patterns to the user.
 
+**Context compaction**: Write phase summary to blackboard:
+  blackboard_write(task_id="{blackboard_id}", key="phase_2_summary", value=JSON.stringify({
+    phase: "Phase 2: Codebase Exploration",
+    agents_used: ["code-explorer-1", ..., "code-explorer-N"],
+    key_findings: [list of essential files, patterns, integration points],
+    complexity_assessment: "simple|medium|complex"
+  }))
+
+Summarize explorer findings into a compact record of key facts. Discard the raw exploration transcripts from your working context — the consolidated codebase_context remains on the blackboard for agents to read.
+
 ## Phase 3: Clarifying Questions
 
 **Goal**: Fill in gaps surfaced by codebase exploration.
@@ -348,6 +390,17 @@ SendMessage to "architect-{i}": "Task #{id} assigned: architecture design. Start
    ```
    blackboard_write(task_id="{blackboard_id}", key="chosen_architecture", value="{selected blueprint}")
    ```
+
+**Context compaction**: Write phase summary to blackboard:
+  blackboard_write(task_id="{blackboard_id}", key="phase_4_summary", value=JSON.stringify({
+    phase: "Phase 4: Architecture Design",
+    agents_used: ["architect-1", ..., "architect-N"],
+    architectures_proposed: [brief name/description for each],
+    chosen_architecture: architecture_name,
+    selection_rationale: "brief rationale"
+  }))
+
+Summarize architect proposals into a compact record of key decisions. Discard the raw design transcripts from your working context — the chosen_architecture remains on the blackboard for agents to read.
 
 ## Phase 4.5: Test Architecture Planning
 
@@ -437,14 +490,39 @@ SendMessage to "test-planner": "Task #{id} assigned: create test plan for chosen
 
 For `i = 1` to `max_iterations`:
 
+Inform user: "Autonomous iteration {i}/{max_iterations}: Starting MODIFY phase — targeting: {contract priorities or 'baseline improvements'}."
+
+#### Sprint Contract (Autonomous Only)
+
+Before each iteration, negotiate what "done" looks like:
+
+1. If architects were spawned:
+   - **TaskCreate**: "Propose priorities for autonomous iteration {i}. Read blackboard key 'iteration_{i-1}_weaknesses' (if exists). Propose top 3 improvements with testable done-criteria."
+     - Assign to first available architect
+   - Write contract to blackboard: key="iteration_{i}_contract"
+
 #### 5.2.A: MODIFY — Implement Iteration
 
-1. **TaskCreate**: "Iteration {i}: Implement the feature [{feature}] following the chosen architecture. Read codebase_context, chosen_architecture, clarifications, and feature_spec from blackboard. {If i > 1: 'Build on previous iteration. Focus on addressing weaknesses from prior scoring.'} Write clean, well-integrated code."
+1. If iteration > 1: read blackboard key `iteration_{i-1}_weaknesses` and include `priority_for_next` as explicit targets for feature-code
+2. **TaskCreate**: "Iteration {i}: Implement the feature [{feature}] following the chosen architecture. Read codebase_context, chosen_architecture, clarifications, and feature_spec from blackboard. {If i > 1: 'Build on previous iteration. Focus on addressing weaknesses from prior scoring. Priority targets: {priority_for_next from iteration_{i-1}_weaknesses}.'} Write clean, well-integrated code."
    - Assign to "feature-code", send message, wait for completion
-2. **TaskCreate**: "Iteration {i}: Run the existing test suite against the updated implementation. The test plan is fixed (from Phase 4.5). Do NOT modify test logic — only verify pass/fail status. Write results to {workspace}/iteration-{i}/test-results.json."
+3. **TaskCreate**: "Iteration {i}: Run the existing test suite against the updated implementation. The test plan is fixed (from Phase 4.5). Do NOT modify test logic — only verify pass/fail status. Write results to {workspace}/iteration-{i}/test-results.json."
    - Assign to "test-writer", send message, wait for completion
-3. If test failures: coordinate fix with feature-code, re-test (max 3 attempts)
-4. Track `changelog` from agent reports
+4. If test failures: coordinate fix with feature-code, re-test (max 3 attempts)
+5. Track `changelog` from agent reports
+
+#### 5.2.A.1: Evaluator Pass (Autonomous)
+
+The code-reviewer acts as an independent evaluator — grading the iteration against the chosen architecture BEFORE scoring. This separation catches issues that self-evaluation misses.
+
+1. **TaskCreate**: "EVALUATOR MODE: Grade iteration {i} implementation against the chosen architecture blueprint (blackboard key 'chosen_architecture'). For each acceptance criterion: (1) Is it implemented? (2) Is the implementation correct? (3) Are there gaps? Report PASS or FAIL with specific findings."
+   - **TaskUpdate**: assign owner to "evaluator" (spawn code-reviewer with name "evaluator" if not already spawned)
+   - **SendMessage** to "evaluator": "Task #{id} assigned: evaluate iteration {i} against architecture. Start now."
+2. Wait for completion
+3. If evaluator reports FAIL:
+   - Send findings to feature-code for remediation
+   - Wait for fixes
+   - Re-run evaluator (max 2 rounds)
 
 #### 5.2.B: EVALUATE — Score the Iteration
 
@@ -454,6 +532,18 @@ For `i = 1` to `max_iterations`:
    - Assign to "code-reviewer", send message, wait for completion
 4. Compute: `bash scripts/score.sh {workspace} {i} {score_weights.tests} {score_weights.quality} {score_weights.security}`
 5. Store as `score_i`
+
+#### Write Weakness Feedback
+
+blackboard_write(task_id="{blackboard_id}", key="iteration_{i}_weaknesses", value=JSON.stringify({
+  iteration: i,
+  score: score_i,
+  low_scoring_areas: [from review-scores.json],
+  evaluator_feedback: [from evaluator pass],
+  priority_for_next: [top 3 areas to improve]
+}))
+
+The next iteration reads this to know exactly what to focus on, replacing vague "build on previous iteration" guidance.
 
 #### 5.2.C: KEEP or DISCARD
 
@@ -467,9 +557,22 @@ For `i = 1` to `max_iterations`:
   - `action = "reverted"`
   - Inform user: "Iteration {i}: score {score_i} (no improvement). REVERTED to v{best.version}."
 
+Inform user: "Autonomous iteration {i}/{max_iterations}: EVALUATE complete — score {score_i}. {KEPT/DISCARDED}."
+
 #### 5.2.D: LOG
 
 `bash scripts/results_log.sh append {workspace}/results.tsv {i} {score_i} {best.score} {action} "{changelog}"`
+
+**Checkpoint**: Write checkpoint to blackboard after each iteration:
+  blackboard_write(task_id="{blackboard_id}", key="checkpoint", value=JSON.stringify({
+    checkpoint_phase: "Phase 5-auto",
+    iteration: i,
+    best_score: best.score,
+    feature_spec: feature_spec_summary,
+    chosen_architecture: architecture_name,
+    files_modified: [...],
+    autonomous_mode: true
+  }))
 
 #### 5.2.E: CONVERGENCE CHECK
 
@@ -553,6 +656,8 @@ Agent tool with:
 
 ### Step 5.2: Implement
 
+Inform user: "Implementation: feature-code working on {feature description}..."
+
 1. **TaskCreate**: "Implement the feature [{feature}] following the chosen architecture blueprint. Read codebase_context, chosen_architecture, clarifications, and feature_spec from the blackboard. Follow codebase conventions strictly. Write clean, well-integrated code. Write implementation_report to blackboard when done."
    - **TaskUpdate**: assign owner to "feature-code"
    - **SendMessage** to "feature-code": "Task #{id} assigned: implement feature. Start now."
@@ -569,6 +674,26 @@ Agent tool with:
    - **SendMessage** to "test-writer": "Task #{id} assigned: generate test code from plan. Start now."
 2. Wait for completion.
 3. Read `test_generation_report` from blackboard.
+
+Inform user: "Implementation complete. Running evaluator pass..."
+
+### Step 5.3.5: Evaluator Pass
+
+The code-reviewer acts as an independent evaluator — grading the implementation against the chosen architecture BEFORE the full review swarm runs. This separation catches issues that self-evaluation misses.
+
+1. **Spawn code-reviewer in evaluator mode** (if not already spawned):
+   - Spawn one code-reviewer with name "evaluator" and prompt focused on grading against acceptance criteria
+
+2. **TaskCreate**: "EVALUATOR MODE: Grade the feature implementation against the chosen architecture blueprint (blackboard key 'chosen_architecture'). For each acceptance criterion: (1) Is it implemented? (2) Is the implementation correct? (3) Are there gaps? Report PASS or FAIL with specific findings."
+   - **TaskUpdate**: assign owner to "evaluator"
+   - **SendMessage** to "evaluator": "Task #{id} assigned: evaluate implementation against architecture. Start now."
+3. Wait for completion
+4. If evaluator reports FAIL:
+   - Send findings to feature-code for remediation
+   - Wait for fixes
+   - Re-run evaluator (max 2 rounds)
+
+Inform user: "Evaluator: {PASS/FAIL}. Proceeding to tests..."
 
 ### Step 5.4: Test Verification
 
@@ -678,9 +803,9 @@ SendMessage to "code-reviewer-{i}": "Task #{id} assigned: feature review. Start 
        - **TaskUpdate**: assign owner to "feature-code"
        - **SendMessage** to "feature-code": "Task #{id} assigned: fix code review findings. Start now."
      - Wait for completion.
-   - If gate failed but `rigor_score >= 0.5` and `coverage_pct >= 60%`: auto-override with relaxed autonomous thresholds. Log: "Quality gate auto-overridden (autonomous): rigor {rigor_score}, coverage {coverage_pct}%."
+   - If gate failed but `rigor_score >= ta_config.autonomousMinimumRigorScore` and `coverage_pct >= ta_config.autonomousMinimumCoverage`: auto-override with relaxed autonomous thresholds. Log: "Quality gate auto-overridden (autonomous): rigor {rigor_score}, coverage {coverage_pct}%."
    - If gate failed below relaxed thresholds: attempt one fix cycle:
-     - **TaskCreate**: "Improve implementation to raise quality gate scores. Current: rigor {rigor_score}, coverage {coverage_pct}%. Target: rigor >= 0.5, coverage >= 60%."
+     - **TaskCreate**: "Improve implementation to raise quality gate scores. Current: rigor {rigor_score}, coverage {coverage_pct}%. Target: rigor >= {ta_config.autonomousMinimumRigorScore}, coverage >= {ta_config.autonomousMinimumCoverage}%."
        - **TaskUpdate**: assign owner to "feature-code"
        - **SendMessage** to "feature-code": "Task #{id} assigned: improve implementation for quality gate. Start now."
      - **TaskCreate**: "Improve test coverage to meet quality gate. Current: {coverage_pct}%. Add tests for uncovered paths identified in coverage_report."
@@ -712,6 +837,19 @@ SendMessage to "code-reviewer-{i}": "Task #{id} assigned: feature review. Start 
 7. **If gate passed OR user chose Override** (or autonomous auto-resolved):
    - Store `quality_gate_override = !gate_passed` for summary reporting
    - Proceed to Phase 7
+
+**Context compaction**: Write phase summary to blackboard:
+  blackboard_write(task_id="{blackboard_id}", key="phase_6_summary", value=JSON.stringify({
+    phase: "Phase 6: Quality Review",
+    agents_used: ["code-reviewer-1", ..., "code-reviewer-N", "test-rigor-reviewer", "coverage-analyst"],
+    rigor_score: rigor_score,
+    coverage_pct: coverage_pct,
+    gate_passed: gate_passed,
+    quality_gate_override: quality_gate_override,
+    key_findings: [consolidated high-severity findings]
+  }))
+
+Summarize review findings into a compact record. Discard the raw review transcripts from your working context — the consolidated results remain on the blackboard.
 
 ## Phase 7: Summary + Cleanup
 
@@ -849,11 +987,20 @@ Suggested next steps:
 | `reviewer_{i}_findings` | code-reviewer-{i} | team lead | 6 |
 | `test_rigor_report` | test-rigor-reviewer | team lead | 6 |
 | `coverage_report` | coverage-analyst | team lead | 6 |
+| `checkpoint` | team lead | team lead | 0.1.5, 2, 4, 4.5, 5-auto |
+| `phase_2_summary` | team lead | team lead | 2 |
+| `phase_4_summary` | team lead | team lead | 4 |
+| `phase_6_summary` | team lead | team lead | 6 |
+| `iteration_{i}_weaknesses` | team lead | feature-code | 5-auto |
+| `iteration_{i}_contract` | architect | team lead, feature-code | 5-auto |
 
 ### Context Distribution
 - **Blackboard is primary**: All agents read context from the blackboard using their documented read keys
 - **Write once, read many**: Feature spec written in Phase 1, codebase context in Phase 2 — all downstream agents read as needed
 - **Inline fallback**: If blackboard is unavailable, embed context directly in task descriptions
+- **Validation**: After writing critical keys (`feature_spec`, `codebase_context`, `chosen_architecture`, `test_plan`, `checkpoint`), immediately read back:
+  result = blackboard_read(task_id="{blackboard_id}", key="<key>")
+If result is null or empty: retry the write once. If still failing, use the inline fallback and log a warning.
 
 ### Interactive Gates
 - **Phase 1**: 95% confidence elicitation — must understand the feature

--- a/skills/feature-dev/SKILL.md
+++ b/skills/feature-dev/SKILL.md
@@ -58,7 +58,7 @@ After extracting flags, the remaining `$ARGUMENTS` is the feature description. I
 3. **If file does NOT exist**: Create with defaults and proceed.
 
 **Config schema v4.0** — feature-dev uses the `featureDev` and (if autonomous) `autonomous` sections:
-```json
+```jsonc
 {
   "version": "4.0",
   "iterations": 3,

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -60,6 +60,8 @@ Parse `$ARGUMENTS` for the following **before** any other processing:
   6. Set `is_focused = true`
   7. If `--focus` is not provided: set `is_focused = false` and `active_agents = {code-explorer, architect, refactor-test, refactor-code, simplifier, code-reviewer}` (all 6 — test-architect agents excluded unless explicitly focused)
 
+- `--context-reset` — Reset orchestrator context between major phases. Writes full state to blackboard checkpoint, then spawns a fresh session to continue from the next phase. Use for extremely long autonomous runs (20+ iterations). Default: summarize-and-discard without context reset.
+
 After extracting flags, the remaining arguments are interpreted as:
 - If empty: refactor the entire codebase
 - If file path: refactor specific file(s)
@@ -186,6 +188,20 @@ You MUST use the full swarm pattern: TeamCreate → TaskCreate → Agent with te
    ```
    Store the returned blackboard ID as `blackboard_id`. This will be passed to all teammates at spawn time so they can read/write shared context (codebase maps, baseline data, iteration results).
 
+**Step 0.2.3**: Check for existing checkpoint from a prior interrupted run:
+   ```
+   blackboard_read(task_id="{blackboard_id}", key="checkpoint")
+   ```
+
+   If checkpoint exists and is valid (non-null, parseable JSON):
+   - Display: "Found checkpoint from prior run: Phase {checkpoint.checkpoint_phase}, Iteration {checkpoint.iteration}, Score {checkpoint.best_score}."
+   - **In interactive mode** (`autonomous_mode = false`): Ask user "Resume from checkpoint or restart fresh?" via AskUserQuestion
+   - **In autonomous mode** (`autonomous_mode = true`): Resume automatically.
+   - **If resume**: restore state variables from checkpoint (`refactoring_iteration`, `best`, `scope`, `active_agents`, `autonomous_mode`), skip completed phases by jumping to the phase indicated in `checkpoint.checkpoint_phase`
+   - **If restart**: clear checkpoint via `blackboard_write(task_id="{blackboard_id}", key="checkpoint", value="")` and proceed normally
+
+   If checkpoint does not exist or is empty: proceed normally.
+
 3. Use **TaskCreate** to create the high-level phase tasks:
    - "Phase 0.5: Deep codebase discovery" (if code-explorer in active_agents)
    - "Phase 1: Foundation analysis (parallel)"
@@ -195,9 +211,16 @@ You MUST use the full swarm pattern: TeamCreate → TaskCreate → Agent with te
    - "Phase 4: Report and cleanup"
    - **If autonomous_mode**: Create workspace directory: `{scope-slug}-autonomous/`
 
-### Step 0.3: Spawn Teammates
+### Step 0.3: Spawn Teammates (Deferred Spawning)
 
-Spawn only agents in `active_agents` using the **Agent tool** with `team_name: "refactor-team"`. The `team_name` parameter is REQUIRED on every Agent call — it registers the agent as a persistent teammate rather than a fire-and-forget subagent. Launch all selected agents in parallel.
+Spawn agents in phases to avoid wasting resources on early exit (e.g., scope clarification failure, discovery finding nothing to refactor). Only immediately-needed agents spawn here; others spawn just before their first use.
+
+**Phase 0.3 (upfront)**: code-explorer, refactor-test, refactor-code — needed for discovery and foundation.
+**Phase 1 (Step 0.9)**: architect, code-reviewer — deferred until after discovery completes successfully.
+**Phase 2 (at iteration start)**: simplifier, test-planner, test-writer, test-rigor-reviewer, coverage-analyst — deferred until the iteration loop begins.
+**convergence-reporter**: Spawned at finalization (no change).
+
+Spawn using the **Agent tool** with `team_name: "refactor-team"`. The `team_name` parameter is REQUIRED on every Agent call — it registers the agent as a persistent teammate rather than a fire-and-forget subagent. Launch all selected agents in parallel.
 
 Each teammate receives the same task-discovery protocol and blackboard ID in their spawn prompt. This is critical for preventing stuck agents:
 
@@ -236,50 +259,7 @@ TASK DISCOVERY PROTOCOL:
      6. NEVER commit code via git — only the team lead commits."
    ```
 
-2. **architect** teammate (**If "architect" in active_agents**):
-   ```
-   Agent tool with:
-     subagent_type: "refactor:architect"
-     team_name: "refactor-team"
-     name: "architect"
-     prompt: "You are the architect agent on a refactoring swarm team. The scope is: {scope}.
-
-     BLACKBOARD: {blackboard_id}
-     Use blackboard_read(task_id='{blackboard_id}', key='codebase_context') to read the codebase map from discovery.
-     Use blackboard_write to share your optimization plans with key 'architect_plan'.
-
-     TASK DISCOVERY PROTOCOL:
-     1. When you receive a message from the team lead, immediately call TaskList to find tasks assigned to you.
-     2. Call TaskGet on your assigned task to read the full description.
-     3. Work on the task.
-     4. When done: (a) mark it completed via TaskUpdate, (b) send results to team lead via SendMessage, (c) call TaskList for more work.
-     5. If no tasks assigned, wait for next message.
-     6. NEVER commit code via git — only the team lead commits."
-   ```
-
-3. **code-reviewer** teammate (**If "code-reviewer" in active_agents**):
-   ```
-   Agent tool with:
-     subagent_type: "refactor:code-reviewer"
-     team_name: "refactor-team"
-     name: "code-reviewer"
-     prompt: "You are the code reviewer agent on a refactoring swarm team. The scope is: {scope}.
-     You handle BOTH quality review (bugs, logic, conventions with confidence scoring) AND security review (regressions, secrets, OWASP with severity classification).
-
-     BLACKBOARD: {blackboard_id}
-     Use blackboard_read(task_id='{blackboard_id}', key='codebase_context') to read the codebase map from discovery.
-     Use blackboard_write to share your baseline with key 'reviewer_baseline'.
-
-     TASK DISCOVERY PROTOCOL:
-     1. When you receive a message from the team lead, immediately call TaskList to find tasks assigned to you.
-     2. Call TaskGet on your assigned task to read the full description.
-     3. Work on the task.
-     4. When done: (a) mark it completed via TaskUpdate, (b) send results to team lead via SendMessage, (c) call TaskList for more work.
-     5. If no tasks assigned, wait for next message.
-     6. NEVER commit code via git — only the team lead commits."
-   ```
-
-4. **refactor-test** teammate (**Always spawned**):
+2. **refactor-test** teammate (**Always spawned**):
    ```
    Agent tool with:
      subagent_type: "refactor:refactor-test"
@@ -299,7 +279,7 @@ TASK DISCOVERY PROTOCOL:
      6. NEVER commit code via git — only the team lead commits."
    ```
 
-5. **refactor-code** teammate (**Always spawned**):
+3. **refactor-code** teammate (**Always spawned**):
    ```
    Agent tool with:
      subagent_type: "refactor:refactor-code"
@@ -320,111 +300,9 @@ TASK DISCOVERY PROTOCOL:
      6. NEVER commit code via git — only the team lead commits."
    ```
 
-6. **simplifier** teammate (**If "simplifier" in active_agents**):
-   ```
-   Agent tool with:
-     subagent_type: "refactor:simplifier"
-     team_name: "refactor-team"
-     name: "simplifier"
-     prompt: "You are the simplifier agent on a refactoring swarm team. The scope is: {scope}.
+**Agents 4-8 (simplifier, test-planner, test-writer, test-rigor-reviewer, coverage-analyst) are deferred to Phase 2** — see "Step 2.0.1: Spawn Phase 2 Agents" below. This avoids spawning agents that sit idle through discovery and foundation analysis.
 
-     BLACKBOARD: {blackboard_id}
-     Use blackboard_read(task_id='{blackboard_id}', key='codebase_context') to read the codebase map from discovery.
-
-     TASK DISCOVERY PROTOCOL:
-     1. When you receive a message from the team lead, immediately call TaskList to find tasks assigned to you.
-     2. Call TaskGet on your assigned task to read the full description.
-     3. Work on the task.
-     4. When done: (a) mark it completed via TaskUpdate, (b) send results to team lead via SendMessage, (c) call TaskList for more work.
-     5. If no tasks assigned, wait for next message.
-     6. NEVER commit code via git — only the team lead commits."
-   ```
-
-7. **test-planner** teammate (**If "test-planner" in active_agents**):
-   ```
-   Agent tool with:
-     subagent_type: "refactor:test-planner"
-     team_name: "refactor-team"
-     name: "test-planner"
-     prompt: "You are the test planner agent on a refactoring swarm team. The scope is: {scope}.
-
-     BLACKBOARD: {blackboard_id}
-     Use blackboard_read(task_id='{blackboard_id}', key='codebase_context') to read the codebase map.
-     Use blackboard_write to share your test plan with key 'test_plan'.
-
-     TASK DISCOVERY PROTOCOL:
-     1. When you receive a message from the team lead, immediately call TaskList to find tasks assigned to you.
-     2. Call TaskGet on your assigned task to read the full description.
-     3. Work on the task.
-     4. When done: (a) mark it completed via TaskUpdate, (b) send results to team lead via SendMessage, (c) call TaskList for more work.
-     5. If no tasks assigned, wait for next message.
-     6. NEVER commit code via git — only the team lead commits."
-   ```
-
-8. **test-writer** teammate (**If "test-writer" in active_agents**):
-   ```
-   Agent tool with:
-     subagent_type: "refactor:test-writer"
-     team_name: "refactor-team"
-     name: "test-writer"
-     prompt: "You are the test writer agent on a refactoring swarm team. The scope is: {scope}. TDD red phase: tests MUST compile but FAIL.
-
-     BLACKBOARD: {blackboard_id}
-     Use blackboard_read(task_id='{blackboard_id}', key='codebase_context') to read the codebase map.
-     Use blackboard_read(task_id='{blackboard_id}', key='test_plan') to read the test plan.
-
-     TASK DISCOVERY PROTOCOL:
-     1. When you receive a message from the team lead, immediately call TaskList to find tasks assigned to you.
-     2. Call TaskGet on your assigned task to read the full description.
-     3. Work on the task.
-     4. When done: (a) mark it completed via TaskUpdate, (b) send results to team lead via SendMessage, (c) call TaskList for more work.
-     5. If no tasks assigned, wait for next message.
-     6. NEVER commit code via git — only the team lead commits."
-   ```
-
-9. **test-rigor-reviewer** teammate (**If "test-rigor-reviewer" in active_agents**):
-   ```
-   Agent tool with:
-     subagent_type: "refactor:test-rigor-reviewer"
-     team_name: "refactor-team"
-     name: "test-rigor-reviewer"
-     prompt: "You are the test rigor reviewer agent on a refactoring swarm team. The scope is: {scope}.
-
-     BLACKBOARD: {blackboard_id}
-     Use blackboard_read(task_id='{blackboard_id}', key='codebase_context') to read the codebase map.
-     Use blackboard_read(task_id='{blackboard_id}', key='test_plan') to cross-reference against the plan.
-
-     TASK DISCOVERY PROTOCOL:
-     1. When you receive a message from the team lead, immediately call TaskList to find tasks assigned to you.
-     2. Call TaskGet on your assigned task to read the full description.
-     3. Work on the task.
-     4. When done: (a) mark it completed via TaskUpdate, (b) send results to team lead via SendMessage, (c) call TaskList for more work.
-     5. If no tasks assigned, wait for next message.
-     6. NEVER commit code via git — only the team lead commits."
-   ```
-
-10. **coverage-analyst** teammate (**If "coverage-analyst" in active_agents**):
-    ```
-    Agent tool with:
-      subagent_type: "refactor:coverage-analyst"
-      team_name: "refactor-team"
-      name: "coverage-analyst"
-      prompt: "You are the coverage analyst agent on a refactoring swarm team. The scope is: {scope}.
-
-      BLACKBOARD: {blackboard_id}
-      Use blackboard_read(task_id='{blackboard_id}', key='codebase_context') to read the codebase map.
-      Use blackboard_write to share your coverage report with key 'coverage_report'.
-
-      TASK DISCOVERY PROTOCOL:
-      1. When you receive a message from the team lead, immediately call TaskList to find tasks assigned to you.
-      2. Call TaskGet on your assigned task to read the full description.
-      3. Work on the task.
-      4. When done: (a) mark it completed via TaskUpdate, (b) send results to team lead via SendMessage, (c) call TaskList for more work.
-      5. If no tasks assigned, wait for next message.
-      6. NEVER commit code via git — only the team lead commits."
-    ```
-
-11. **convergence-reporter** teammate (**If autonomous_mode is true** — spawned deferred, at finalization):
+4. **convergence-reporter** teammate (**If autonomous_mode is true** — spawned deferred, at finalization):
    ```
    Agent tool with:
      subagent_type: "refactor:convergence-reporter"
@@ -445,6 +323,53 @@ TASK DISCOVERY PROTOCOL:
      6. NEVER commit code via git — only the team lead commits."
    ```
    **Note**: Do NOT spawn this agent in Phase 0.3. Spawn it in Phase 2 Step 2.2 (Finalization) when the convergence loop completes.
+
+### Step 0.9: Spawn Phase 1 Agents
+
+**Spawn architect and code-reviewer just before they are needed.** These agents are deferred from Phase 0.3 to avoid wasting resources if the run exits early (e.g., scope clarification failure, discovery finding nothing actionable).
+
+1. **architect** teammate (**If "architect" in active_agents**):
+   ```
+   Agent tool with:
+     subagent_type: "refactor:architect"
+     team_name: "refactor-team"
+     name: "architect"
+     prompt: "You are the architect agent on a refactoring swarm team. The scope is: {scope}.
+
+     BLACKBOARD: {blackboard_id}
+     Use blackboard_read(task_id='{blackboard_id}', key='codebase_context') to read the codebase map from discovery.
+     Use blackboard_write to share your optimization plans with key 'architect_plan'.
+
+     TASK DISCOVERY PROTOCOL:
+     1. When you receive a message from the team lead, immediately call TaskList to find tasks assigned to you.
+     2. Call TaskGet on your assigned task to read the full description.
+     3. Work on the task.
+     4. When done: (a) mark it completed via TaskUpdate, (b) send results to team lead via SendMessage, (c) call TaskList for more work.
+     5. If no tasks assigned, wait for next message.
+     6. NEVER commit code via git — only the team lead commits."
+   ```
+
+2. **code-reviewer** teammate (**If "code-reviewer" in active_agents**):
+   ```
+   Agent tool with:
+     subagent_type: "refactor:code-reviewer"
+     team_name: "refactor-team"
+     name: "code-reviewer"
+     prompt: "You are the code reviewer agent on a refactoring swarm team. The scope is: {scope}.
+     You handle BOTH quality review (bugs, logic, conventions with confidence scoring) AND security review (regressions, secrets, OWASP with severity classification).
+
+     BLACKBOARD: {blackboard_id}
+     Use blackboard_read(task_id='{blackboard_id}', key='codebase_context') to read the codebase map from discovery.
+     Use blackboard_write to share your baseline with key 'reviewer_baseline'.
+
+     TASK DISCOVERY PROTOCOL:
+     1. When you receive a message from the team lead, immediately call TaskList to find tasks assigned to you.
+     2. Call TaskGet on your assigned task to read the full description.
+     3. Work on the task.
+     4. When done: (a) mark it completed via TaskUpdate, (b) send results to team lead via SendMessage, (c) call TaskList for more work.
+     5. If no tasks assigned, wait for next message.
+     6. NEVER commit code via git — only the team lead commits."
+   ```
 
 ## Phase 0.5: Discovery
 
@@ -471,9 +396,39 @@ Write `codebase_context` to the shared blackboard for cross-agent access:
 1. **Write to blackboard**: Call `blackboard_write(task_id="{blackboard_id}", key="codebase_context", value=codebase_context)`. All teammates already have `blackboard_id` from their spawn prompts and can read via `blackboard_read`.
 2. **Fallback** (if blackboard write fails): Include `codebase_context` directly in every downstream task description under a `## Codebase Context` section.
 
+**Validation**: After writing critical keys (`codebase_context`, `architect_plan`, `reviewer_baseline`, `checkpoint`), immediately read back the key to verify:
+  ```
+  result = blackboard_read(task_id="{blackboard_id}", key="codebase_context")
+  ```
+If result is null or empty: retry the write once. If still failing, use the inline fallback.
+
 ### Step 0.5.4: Checkpoint
 
 - Inform user: "Phase 0.5 complete. Codebase discovery finished. {summary of key findings — entry points, layers, patterns}. Starting foundation analysis."
+- Write checkpoint:
+  ```
+  blackboard_write(task_id="{blackboard_id}", key="checkpoint", value=JSON.stringify({
+    checkpoint_phase: "Phase 0.5",
+    iteration: 0,
+    best_score: null,
+    best_snapshot_branch: null,
+    files_modified_total: [],
+    scope: scope,
+    active_agents: [...active_agents],
+    autonomous_mode: autonomous_mode
+  }))
+  ```
+- Write phase summary to blackboard:
+  ```
+  blackboard_write(task_id="{blackboard_id}", key="phase_0_5_summary", value=JSON.stringify({
+    phase: "Phase 0.5: Discovery",
+    agents_used: ["code-explorer"],
+    key_outputs: ["codebase_context written to blackboard"],
+    entry_points_found: N,
+    patterns_identified: [...summary...]
+  }))
+  ```
+- **Context compaction**: Summarize the code-explorer's findings into a compact list of key facts (entry points, layers, patterns, issues). Discard the raw exploration transcript from your working context — agents can still read the full `codebase_context` from the blackboard.
 
 ## Phase 1: Foundation (Parallel)
 
@@ -531,15 +486,52 @@ After Phase 1 parallel tasks complete, run sequential test-architect steps:
 
 ### Step 1.4: Checkpoint
 
+- Write checkpoint:
+  ```
+  blackboard_write(task_id="{blackboard_id}", key="checkpoint", value=JSON.stringify({
+    checkpoint_phase: "Phase 1",
+    iteration: 0,
+    best_score: null,
+    best_snapshot_branch: null,
+    files_modified_total: [],
+    scope: scope,
+    active_agents: [...active_agents],
+    autonomous_mode: autonomous_mode
+  }))
+  ```
 - Inform user with a message reflecting which agents ran:
   - Full run: "Phase 1 complete. Test coverage established. Architecture reviewed. Quality + security baseline recorded. Starting iteration loop."
   - Focused run: "Phase 1 complete. Test coverage established.{' Architecture reviewed.' if architect active}{' Quality + security baseline recorded.' if code-reviewer active}{' Test plan generated.' if test-planner active}{' Test code generated (TDD red phase).' if test-writer active}{' Test rigor score: X/1.0.' if test-rigor-reviewer active}{' Coverage: Y%.' if coverage-analyst active} Starting iteration loop ({max_iterations} iteration{s})."
+- Write phase summary to blackboard:
+  ```
+  blackboard_write(task_id="{blackboard_id}", key="phase_1_summary", value=JSON.stringify({
+    phase: "Phase 1: Foundation",
+    agents_used: [list of agents that ran in Phase 1],
+    key_outputs: ["test baseline established", "architect plan written", "reviewer baseline recorded"],
+    test_status: "all passing" or "failures noted",
+    architect_priorities: [top 3 if architect ran],
+    security_baseline: summary if code-reviewer ran
+  }))
+  ```
+- **Context compaction**: Summarize each agent's Phase 1 output into key facts (test count, coverage %, top priorities, baseline findings count). Discard verbose agent transcripts from your working context — agents can still read full outputs from the blackboard.
 
 ## Phase 2: Autonomous Convergence Loop (when `autonomous_mode = true`)
 
 **Replaces the standard Phase 2 when `--autonomous` is active. All other phases (0, 0.5, 1, 3, 4) execute with autonomous gate bypasses — no user interaction. See argument parsing above for per-phase autonomous behavior.**
 
 **Goal**: Iteratively improve code quality through the same agent sub-steps, but with composite scoring, keep/discard gating, and automatic convergence detection. See `references/autonomous-algorithm.md` for the formal specification.
+
+**Spawn Phase 2 agents now** (deferred from Phase 0.3 to avoid idle agents during discovery and foundation):
+
+Spawn the following agents if they are in `active_agents` and have not already been spawned. Launch all in parallel:
+
+- **simplifier** — `subagent_type: "refactor:simplifier"`, prompt includes blackboard ID and task discovery protocol (see Phase 0.3 template pattern)
+- **test-planner** — `subagent_type: "refactor:test-planner"`, prompt includes blackboard ID, writes test plan to key `test_plan`
+- **test-writer** — `subagent_type: "refactor:test-writer"`, prompt includes blackboard ID, reads `test_plan` key
+- **test-rigor-reviewer** — `subagent_type: "refactor:test-rigor-reviewer"`, prompt includes blackboard ID, reads `test_plan` for cross-reference
+- **coverage-analyst** — `subagent_type: "refactor:coverage-analyst"`, prompt includes blackboard ID, writes coverage report to key `coverage_report`
+
+Use the same spawn template pattern as Phase 0.3 (Agent tool with `team_name: "refactor-team"`, scope, blackboard ID, and task discovery protocol).
 
 ### Step 2.0: Initialize Workspace
 
@@ -570,10 +562,25 @@ After Phase 1 parallel tasks complete, run sequential test-architect steps:
 
 For `i = 1` to `max_iterations`:
 
+Inform user: "Autonomous iteration {i}/{max_iterations}: Starting MODIFY phase — {contract priorities from iteration_{i}_contract if available, else 'baseline priorities'}."
+
+#### 2.1.A.0: Sprint Contract (Autonomous Only)
+
+Before each iteration, the architect and evaluator negotiate what "done" looks like:
+
+1. If "architect" in active_agents:
+   - **TaskCreate**: "Propose priorities for iteration {i}. Based on the current state of [{scope}] and {if i > 1: 'weaknesses from iteration ' + (i-1) else: 'the baseline assessment'}, propose the top 3 improvements to make. For each, define what 'done' looks like — specific, testable criteria."
+     - **TaskUpdate**: assign owner to "architect"
+     - **SendMessage** to "architect": "Task #{id} assigned: propose iteration {i} sprint contract. Start now."
+   - Wait for completion
+   - Write to blackboard: `blackboard_write(task_id="{blackboard_id}", key="iteration_{i}_contract", value=architect's contract proposal)`
+
 #### 2.1.A: MODIFY — Execute One Iteration
 
 Run the standard Phase 2 sub-steps (2.A through 2.G) with these constraints:
 - **Tests are FROZEN**: When assigning tasks to refactor-test, always include: "Run tests ONLY — do NOT create, modify, or delete any test files. Tests are frozen during autonomous mode."
+- **Evaluator pass** (Step 2.B.1) runs after implementation in each iteration — the separated evaluator is especially important in autonomous mode where there is no human to catch self-evaluation blindness
+- **Read prior weakness feedback**: If iteration > 1, read blackboard key `iteration_{i-1}_weaknesses` and include the `priority_for_next` items as explicit targets in the architect review and refactor-code tasks
 - All other sub-steps (architect review, implement optimizations, code review, simplify) execute normally
 - Track `changelog` = summary of changes made in this iteration (from agent reports)
 
@@ -592,6 +599,23 @@ After sub-steps complete:
    - Wait for completion
 4. Compute score: Run via Bash: `bash scripts/score.sh {workspace} {i} {score_weights.tests} {score_weights.quality} {score_weights.security}`
 5. Store result as `score_i`
+6. Inform user: "Autonomous iteration {i}/{max_iterations}: EVALUATE complete — score {score_i}. {if score_i > best.score: 'KEPT' else: 'DISCARDED'}."
+
+#### 2.1.B.1: Write Weakness Feedback
+
+Write structured feedback for the next iteration:
+
+```
+blackboard_write(task_id="{blackboard_id}", key="iteration_{i}_weaknesses", value=JSON.stringify({
+  iteration: i,
+  score: score_i,
+  low_scoring_areas: [extract from review-scores.json before workspace cleanup],
+  evaluator_feedback: [summary from evaluator pass],
+  priority_for_next: [top 3 areas to improve in next iteration]
+}))
+```
+
+This replaces vague "build on previous iteration" guidance with specific, actionable targets. The next iteration's MODIFY step reads this key to know exactly what to focus on.
 
 #### 2.1.C: KEEP or DISCARD
 
@@ -609,6 +633,33 @@ After sub-steps complete:
 #### 2.1.D: LOG
 
 Run via Bash: `bash scripts/results_log.sh append {workspace}/results.tsv {i} {score_i} {best.score} {action} "{changelog}"`
+
+Write checkpoint:
+```
+blackboard_write(task_id="{blackboard_id}", key="checkpoint", value=JSON.stringify({
+  checkpoint_phase: "Phase 2",
+  iteration: i,
+  best_score: best.score,
+  best_snapshot_branch: "autoresearch/v" + best.version,
+  files_modified_total: [...files_modified_total],
+  scope: scope,
+  active_agents: [...active_agents],
+  autonomous_mode: true
+}))
+```
+
+Write iteration summary to blackboard:
+```
+blackboard_write(task_id="{blackboard_id}", key="iteration_{i}_summary", value=JSON.stringify({
+  phase: "Phase 2: Iteration " + i,
+  agents_used: [agents that ran in this iteration],
+  score: score_i,
+  action: action,
+  changelog: changelog,
+  files_modified: [files changed this iteration]
+}))
+```
+**Context compaction**: Summarize this iteration's results into score, action (kept/reverted), and key changes. Discard verbose agent transcripts — the blackboard retains full details for any agent that needs them.
 
 #### 2.1.E: CONVERGENCE CHECK
 
@@ -677,11 +728,23 @@ Check conditions in order. First match stops the loop:
 
 **Goal**: Iteratively improve code quality through architect -> code -> test -> review -> simplify cycles.
 
+**Step 2.0.1: Spawn Phase 2 Agents** — Spawn the following agents if they are in `active_agents` and have not already been spawned. These were deferred from Phase 0.3 to avoid idle agents during discovery and foundation. Launch all in parallel:
+
+- **simplifier** — `subagent_type: "refactor:simplifier"`, prompt includes blackboard ID and task discovery protocol (see Phase 0.3 template pattern)
+- **test-planner** — `subagent_type: "refactor:test-planner"`, prompt includes blackboard ID, writes test plan to key `test_plan`
+- **test-writer** — `subagent_type: "refactor:test-writer"`, prompt includes blackboard ID, reads `test_plan` key
+- **test-rigor-reviewer** — `subagent_type: "refactor:test-rigor-reviewer"`, prompt includes blackboard ID, reads `test_plan` for cross-reference
+- **coverage-analyst** — `subagent_type: "refactor:coverage-analyst"`, prompt includes blackboard ID, writes coverage report to key `coverage_report`
+
+Use the same spawn template pattern as Phase 0.3 (Agent tool with `team_name: "refactor-team"`, scope, blackboard ID, and task discovery protocol).
+
 Repeat the following for `max_iterations` times:
 
 ### Step 2.A: Architecture Review
 
 **Skip if "architect" not in active_agents.** Also skip on iteration 1 if architect's Phase 1 review is still current. Otherwise:
+
+Inform user: "Iteration {iteration+1}/{max_iterations}: Starting architecture review..."
 
 1. **TaskCreate**: "Iteration {iteration+1}: Review code architecture for [{scope}]. Create prioritized optimization plan. Provide top 3 high-priority optimizations to implement. Focus on improvements not yet addressed in previous iterations.{if codebase_context: '\n\n## Codebase Context\n' + codebase_context}"
    - **TaskUpdate**: assign owner to "architect"
@@ -695,15 +758,36 @@ Repeat the following for `max_iterations` times:
 
 If not skipped:
 
+Inform user: "Iteration {iteration+1}/{max_iterations}: Implementing top 3 optimizations..."
+
 1. **TaskCreate**: "Implement the top 3 optimizations from the architect's plan: [paste architect's top 3]. Preserve all existing functionality. Apply clean code principles. Make incremental, safe changes. Report all files modified. Do NOT commit via git.{if codebase_context: '\n\n## Codebase Context\n' + codebase_context}"
    - **TaskUpdate**: assign owner to "refactor-code"
    - **SendMessage** to "refactor-code": "Task #{id} assigned: implement top 3 optimizations. Start now."
 2. Wait for completion
 3. Record implementation report (files changed, optimizations applied)
 
+### Step 2.B.1: Evaluator Pass
+
+**Skip if "code-reviewer" not in active_agents.**
+
+The code-reviewer acts as an independent evaluator — grading the implementation against the architect's priorities BEFORE tests run. This catches issues that self-evaluation misses (the article "Harness Design for Long-Running Apps" demonstrates that "decoupling the generator from the evaluator proves more tractable than making generators self-critical").
+
+1. **TaskCreate**: "EVALUATOR MODE: Grade the implementation changes from this iteration against the architect's top 3 priorities: [paste priorities]. For each priority, assess: (1) Was it addressed? (2) Is the implementation correct? (3) Are there issues the implementer missed? Report as PASS (all priorities adequately addressed) or FAIL (specific gaps found with remediation guidance)."
+   - **TaskUpdate**: assign owner to "code-reviewer"
+   - **SendMessage** to "code-reviewer": "Task #{id} assigned: evaluator pass on iteration {iteration+1} implementation. Start now."
+2. Wait for completion
+3. Inform user: "Iteration {iteration+1}/{max_iterations}: Evaluator pass complete. {PASS/FAIL}."
+4. If evaluator reports FAIL:
+   - **TaskCreate**: "Fix evaluator findings: [paste findings]. Address each gap while preserving existing improvements."
+     - **TaskUpdate**: assign owner to "refactor-code"
+     - **SendMessage** to "refactor-code": "Task #{id} assigned: fix evaluator findings. Start now."
+   - Wait for completion
+
 ### Step 2.C: Test Verification
 
 **Skip if Step 2.B was skipped** (no implementation changes to verify).
+
+Inform user: "Iteration {iteration+1}/{max_iterations}: Running test verification..."
 
 1. **TaskCreate**: "Run the complete test suite. Report pass/fail status. If failures: provide detailed failure report with causes and suggestions."
    - **TaskUpdate**: assign owner to "refactor-test"
@@ -788,7 +872,11 @@ If code-reviewer reported **FAIL** (Critical/High severity findings or high-conf
 
 1. Increment `refactoring_iteration += 1`
 2. Inform user: "Iteration {refactoring_iteration} of {max_iterations} complete."
-3. **If `config.postRefactor.commitStrategy` is `"per-iteration"`**:
+3. **Zero-change gate**: If refactor-code reported zero files modified in this iteration (nothing to implement), skip remaining iterations:
+   - Inform user: "No changes made in iteration {refactoring_iteration}. Code is stable — skipping remaining {max_iterations - refactoring_iteration} iteration(s)."
+   - Proceed directly to Phase 3.
+   This lightweight convergence check prevents wasting iterations when the code has reached a stable state, without requiring the full autonomous scoring infrastructure.
+4. **If `config.postRefactor.commitStrategy` is `"per-iteration"`**:
    - **Security check**: Before staging, identify and exclude any files matching secret patterns (`.env`, `.env.*`, `credentials.json`, `secrets.*`, `*.pem`, `*.key`, files containing API keys/tokens/passwords). Warn the user if confidential files are detected.
    - Stage all changed files using Bash: `git add -u` (never `git add -A` — it may stage untracked secrets or artifacts)
    - Check for staged changes: `git diff --cached --quiet` — if exit code 0, no changes to commit; skip and log "No changes to commit for this iteration"
@@ -800,8 +888,8 @@ If code-reviewer reported **FAIL** (Critical/High severity findings or high-conf
      )"
      ```
    - If commit fails (e.g., no git, pre-commit hook failure, no changes), log a warning to the user and continue
-4. If `refactoring_iteration < max_iterations`: continue to next iteration (Step 2.A)
-5. If `refactoring_iteration >= max_iterations`: proceed to Phase 3
+5. If `refactoring_iteration < max_iterations`: continue to next iteration (Step 2.A)
+6. If `refactoring_iteration >= max_iterations`: proceed to Phase 3
 
 ## Phase 3: Final Assessment (Parallel)
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -300,7 +300,9 @@ TASK DISCOVERY PROTOCOL:
      6. NEVER commit code via git — only the team lead commits."
    ```
 
-**Agents 4-8 (simplifier, test-planner, test-writer, test-rigor-reviewer, coverage-analyst) are deferred to Phase 2** — see "Step 2.0.1: Spawn Phase 2 Agents" below. This avoids spawning agents that sit idle through discovery and foundation analysis.
+**Agents 4-8 are deferred to avoid idle agents during discovery:**
+- **simplifier**: Deferred to Phase 2 — see "Step 2.0.1: Spawn Phase 2 Agents" below.
+- **test-planner, test-writer, test-rigor-reviewer, coverage-analyst**: Deferred to **Step 0.9** if `testing` is in `active_agents` (they are needed in Phase 1.1/1.3). Otherwise deferred to Phase 2.
 
 4. **convergence-reporter** teammate (**If autonomous_mode is true** — spawned deferred, at finalization):
    ```
@@ -326,7 +328,9 @@ TASK DISCOVERY PROTOCOL:
 
 ### Step 0.9: Spawn Phase 1 Agents
 
-**Spawn architect and code-reviewer just before they are needed.** These agents are deferred from Phase 0.3 to avoid wasting resources if the run exits early (e.g., scope clarification failure, discovery finding nothing actionable).
+**Spawn agents needed for Phase 1 just before they are needed.** These agents are deferred from Phase 0.3 to avoid wasting resources if the run exits early (e.g., scope clarification failure, discovery finding nothing actionable).
+
+**Also spawn testing agents here if `testing` is in the focus areas** — test-planner, test-writer, test-rigor-reviewer, and coverage-analyst are used in Phase 1 Steps 1.1 and 1.3 for testing-focus runs. They must be spawned before Phase 1, not deferred to Phase 2. Use the same spawn templates as defined in Step 2.0.1 but launch them here. If testing is not in focus, they remain deferred to Phase 2.
 
 1. **architect** teammate (**If "architect" in active_agents**):
    ```

--- a/skills/test-architect/SKILL.md
+++ b/skills/test-architect/SKILL.md
@@ -55,10 +55,16 @@ Coverage analysis only: detect → run coverage tools → identify gaps → sugg
 
 ### Step 0.1: Detect Project
 
-Run project detection using the detection script:
+Run project detection using the detection module:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/detect_project.py <target_path>
+python3 -m scripts.detect_project <target_path>
+```
+
+Or, if running from outside the plugin root:
+
+```bash
+python3 -c "import sys; sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}'); from scripts.detect_project import detect_project; import json; print(json.dumps(detect_project(sys.argv[1])))" <target_path>
 ```
 
 Or detect manually:

--- a/tests/test_coverage_report.py
+++ b/tests/test_coverage_report.py
@@ -112,7 +112,12 @@ class TestNormalizeCoverage:
 
         data = {
             "src/main.ts": {
-                "statementMap": {"0": {}, "1": {}, "2": {}, "3": {}},
+                "statementMap": {
+                    "0": {"start": {"line": 5}, "end": {"line": 5}},
+                    "1": {"start": {"line": 10}, "end": {"line": 10}},
+                    "2": {"start": {"line": 15}, "end": {"line": 15}},
+                    "3": {"start": {"line": 20}, "end": {"line": 20}},
+                },
                 "s": {"0": 1, "1": 1, "2": 0, "3": 1},
             }
         }
@@ -121,6 +126,32 @@ class TestNormalizeCoverage:
         assert result["covered_lines"] == 3
         assert result["coverage_pct"] == 75.0
         assert len(result["uncovered_files"]) == 1
+
+    def test_typescript_uncovered_lines_are_source_lines_not_statement_ids(self):
+        """Regression: uncovered_lines must contain source line numbers, not statement IDs.
+
+        In c8/Istanbul JSON, keys in `s` are statement IDs (0, 1, 2...),
+        NOT line numbers. statementMap maps IDs to {start: {line: N}}.
+        The old code returned statement IDs, producing [2] instead of [15].
+        """
+        from scripts.coverage_report import _normalize_typescript_coverage
+
+        data = {
+            "src/handler.ts": {
+                "statementMap": {
+                    "0": {"start": {"line": 5}, "end": {"line": 5}},
+                    "1": {"start": {"line": 10}, "end": {"line": 12}},
+                    "2": {"start": {"line": 42}, "end": {"line": 42}},
+                },
+                "s": {"0": 1, "1": 0, "2": 0},
+            }
+        }
+        result = _normalize_typescript_coverage(data)
+        uncovered = result["uncovered_files"][0]["uncovered_lines"]
+        # Must be real source lines [10, 42], NOT statement IDs [1, 2]
+        assert uncovered == [10, 42]
+        assert 1 not in uncovered
+        assert 2 not in uncovered
 
     def test_normalize_coverage_dispatches_correctly(self):
         from scripts.coverage_report import _normalize_coverage

--- a/tests/test_detect_project.py
+++ b/tests/test_detect_project.py
@@ -103,10 +103,11 @@ class TestDetectProjectCLI:
         """python -m scripts.detect_project <path> must produce valid JSON."""
         import json
         import subprocess
+        import sys
 
         project = tmp_project("python")
         result = subprocess.run(
-            ["python3", "-m", "scripts.detect_project", str(project)],
+            [sys.executable, "-m", "scripts.detect_project", str(project)],
             capture_output=True,
             text=True,
             cwd=str(Path(__file__).parent.parent),
@@ -118,9 +119,10 @@ class TestDetectProjectCLI:
     def test_cli_entry_point_fails_on_bad_path(self):
         """python -m scripts.detect_project /bad/path must exit non-zero."""
         import subprocess
+        import sys
 
         result = subprocess.run(
-            ["python3", "-m", "scripts.detect_project", "/nonexistent/path"],
+            [sys.executable, "-m", "scripts.detect_project", "/nonexistent/path"],
             capture_output=True,
             text=True,
             cwd=str(Path(__file__).parent.parent),

--- a/tests/test_detect_project.py
+++ b/tests/test_detect_project.py
@@ -94,3 +94,35 @@ class TestDetectProject:
         assert "framework" in result
         assert "existing_tests" in result
         assert "path" in result
+
+
+class TestDetectProjectCLI:
+    """Regression: detect_project.py must be runnable as a module via python -m."""
+
+    def test_cli_entry_point_produces_json(self, tmp_project):
+        """python -m scripts.detect_project <path> must produce valid JSON."""
+        import json
+        import subprocess
+
+        project = tmp_project("python")
+        result = subprocess.run(
+            ["python3", "-m", "scripts.detect_project", str(project)],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+        assert result.returncode == 0, f"CLI failed: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["language"] == "python"
+
+    def test_cli_entry_point_fails_on_bad_path(self):
+        """python -m scripts.detect_project /bad/path must exit non-zero."""
+        import subprocess
+
+        result = subprocess.run(
+            ["python3", "-m", "scripts.detect_project", "/nonexistent/path"],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+        assert result.returncode != 0

--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -52,9 +52,40 @@ class TestParsePythonOutput:
 class TestParseTypescriptOutput:
     def test_passing(self, sample_output):
         result = _parse_typescript_output(sample_output("typescript", "passing"))
-        # Regex matches first "N passed" which is "1 passed" from "Test Files  1 passed"
-        assert result["passed"] >= 1
+        assert result["passed"] == 3
         assert result["failed"] == 0
+
+    def test_vitest_prefers_tests_line_over_test_files(self):
+        """Regression: parser must read the 'Tests' summary, not 'Test Files'.
+
+        Vitest emits two lines: 'Test Files  1 passed' and 'Tests  42 passed'.
+        A naive first-match regex returns 1 instead of 42.
+        """
+        output = (
+            " ✓ tests/api.test.ts (42)\n"
+            "\n"
+            " Test Files  1 passed (1)\n"
+            "      Tests  42 passed (42)\n"
+            "   Start at  10:30:15\n"
+            "   Duration  2.34s\n"
+        )
+        result = _parse_typescript_output(output)
+        assert result["passed"] == 42
+        assert result["failed"] == 0
+
+    def test_vitest_mixed_pass_fail(self):
+        """Tests line with both passed and failed counts."""
+        output = " Test Files  2 passed | 1 failed (3)\n      Tests  15 passed | 3 failed (18)\n"
+        result = _parse_typescript_output(output)
+        assert result["passed"] == 15
+        assert result["failed"] == 3
+
+    def test_no_tests_line_falls_back_to_first_match(self):
+        """If no 'Tests' summary line exists, fall back to generic regex."""
+        output = "5 passed, 2 failed\n"
+        result = _parse_typescript_output(output)
+        assert result["passed"] == 5
+        assert result["failed"] == 2
 
 
 class TestParseGoOutput:


### PR DESCRIPTION
## Summary

- Apply Anthropic harness design principles (separated evaluation, context compaction, checkpoint-resume) to `/refactor` and `/feature-dev` skills
- Fix 3 bugs found by Codex review: detect-project CLI entry point, Vitest parser, TypeScript coverage line mapping
- Add regression tests locking in all fixes

## Changes

### Harness Design Overhaul (both skills)
- **Separated evaluator**: code-reviewer grades implementation against priorities BEFORE tests run — catches self-evaluation blindness
- **Sprint contracts**: architect and evaluator negotiate "done" criteria before each autonomous iteration
- **Context compaction**: phase summaries written to blackboard; raw agent reports discarded from orchestrator context
- **Checkpoint-resume**: orchestrator state saved to blackboard after each phase; resume from prior checkpoint on crash
- **Blackboard write validation**: read-back after critical writes with retry and inline fallback
- **Structured inter-iteration feedback**: `iteration_N_weaknesses` written after EVALUATE; next MODIFY reads specific targets
- **Intra-iteration progress reporting**: status messages within each iteration for visibility

### Refactor-specific
- **Deferred agent spawning**: agents spawn on-demand per phase, not all upfront
- **Testing-focus fix**: test-architect agents spawn in Step 0.9 when testing focus is active (not deferred to Phase 2)
- **Zero-change gate**: standard mode exits early when no files modified in an iteration

### Feature-dev-specific
- **Configurable autonomous thresholds**: `autonomousMinimumRigorScore` and `autonomousMinimumCoverage` in config
- **`--context-reset` flag**: full context resets between phases for long autonomous runs

### Codex Review Fixes
- **P1**: `detect_project.py` — added `__main__` block; updated SKILL.md to use `python -m scripts.detect_project`
- **P2**: Vitest parser — now matches `Tests` summary line, not `Test Files` (was reporting `passed=1` instead of `passed=42`)
- **P2**: TypeScript coverage — maps statement IDs through `statementMap` to real source line numbers

## Test Plan

- [x] Full test suite passes (95.64% coverage)
- [x] Vitest parser regression: `test_vitest_prefers_tests_line_over_test_files` asserts `passed==42`
- [x] Coverage mapping regression: `test_typescript_uncovered_lines_are_source_lines_not_statement_ids` asserts `[10, 42]` not `[1, 2]`
- [x] detect_project CLI: `test_cli_entry_point_produces_json` verifies `python -m scripts.detect_project` works
- [x] Autoresearch: refactor skill scored 1.0 (up from 0.983), feature-dev scored 1.0 baseline
- [x] All pre-commit hooks pass (ruff, mypy, bandit)